### PR TITLE
Update JSON compatibility version in Project.toml

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -14,7 +14,7 @@ Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 [compat]
 DataFrames = "1.2"
 HTTP = "1"
-JSON = "0.21"
+JSON = "0.21, 1"
 Unitful = "1.9"
 julia = "1"
 


### PR DESCRIPTION
JSON.jl version 1.0.0 and higher is required to enable compatibility of GeoArtifacts.jl with some other packages.